### PR TITLE
Feature/assignment 1

### DIFF
--- a/.github/workflows/bump-tag-release.yml
+++ b/.github/workflows/bump-tag-release.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - main # This is done so that merges to main are considered releases (Mainline Branching Strategy)
-      - feature/assignment-1 # Testing purposes
 jobs:
   bump_tag_and_release:
     name: Bump Version, Tag and Release
@@ -48,14 +47,13 @@ jobs:
           git commit -m "Bump version from ${{ steps.get_package_version.outputs.package_version }} to $UPDATED_VERSION in package.json [skip ci]"
           git push --set-upstream origin $(git branch --show-current)
 
-
-      # - name: Create Tag and GitHub Release
-      #   uses: actions/create-release@v1
-      #   env:
-      #     GITHUB_TOKEN: ${{ steps.genberate_github_app_token.outputs.token }}
-      #   with:
-      #     tag_name: ${{ steps.get_package_version.outputs.package_version }}
-      #     release_name: ${{ steps.get_package_version.outputs.package_version }}
-      #     draft: false
-      #     prerelease: false
+      - name: Create Tag and GitHub Release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ steps.genberate_github_app_token.outputs.token }}
+        with:
+          tag_name: ${{ steps.get_package_version.outputs.package_version }}
+          release_name: ${{ steps.get_package_version.outputs.package_version }}
+          draft: false
+          prerelease: false
           

--- a/.github/workflows/bump-tag-release.yml
+++ b/.github/workflows/bump-tag-release.yml
@@ -45,7 +45,7 @@ jobs:
           npm version patch --no-git-tag-version
           git add --all
           UPDATED_VERSION=$(node -p "require('./package.json').version")
-          git commit -m "Bump version from ${{ steps.get_package_version.outputs.package_version }} to $UPDATED_VERSION in package.json"
+          git commit -m "Bump version from ${{ steps.get_package_version.outputs.package_version }} to $UPDATED_VERSION in package.json [skip ci]"
           git push --set-upstream origin $(git branch --show-current)
 
       # - name: Create Tag and GitHub Release

--- a/.github/workflows/bump-tag-release.yml
+++ b/.github/workflows/bump-tag-release.yml
@@ -48,6 +48,7 @@ jobs:
           git commit -m "Bump version from ${{ steps.get_package_version.outputs.package_version }} to $UPDATED_VERSION in package.json [skip ci]"
           git push --set-upstream origin $(git branch --show-current)
 
+
       # - name: Create Tag and GitHub Release
       #   uses: actions/create-release@v1
       #   env:

--- a/.github/workflows/bump-tag-release.yml
+++ b/.github/workflows/bump-tag-release.yml
@@ -50,7 +50,7 @@ jobs:
 
       # - name: Create Tag and GitHub Release
       #   uses: actions/create-release@v1
-      #   env:
+      #   env: 
       #     GITHUB_TOKEN: ${{ steps.genberate_github_app_token.outputs.token }}
       #   with:
       #     tag_name: ${{ steps.get_package_version.outputs.package_version }}

--- a/.github/workflows/bump-tag-release.yml
+++ b/.github/workflows/bump-tag-release.yml
@@ -3,9 +3,10 @@ on:
   push:
     branches:
       - main # This is done so that merges to main are considered releases (Mainline Branching Strategy)
+      - feature/assignment-1 # Testing purposes
 jobs:
-  tag_and_release:
-    name: Tag and Release
+  bump_tag_and_release:
+    name: Bump Version, Tag and Release
     runs-on: ubuntu-latest
     steps: 
       - name: Generate GitHub App Token
@@ -25,7 +26,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 14.x
+          node-version: 16.x
           registry-url: https://npm.pkg.github.com/
           scope: '@remla23-team08'
       
@@ -33,19 +34,27 @@ jobs:
         run: |
           git config user.name "GitHub Actions [bot]"
           git config user.email "actions@github.com"
-      
+
       - name: Get package version
         id: get_package_version
         run: | 
           echo ::set-output name=package_version::$(node -p "require('./package.json').version")
 
-      - name: Create Tag and GitHub Release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ steps.genberate_github_app_token.outputs.token }}
-        with:
-          tag_name: ${{ steps.get_package_version.outputs.package_version }}
-          release_name: ${{ steps.get_package_version.outputs.package_version }}
-          draft: false
-          prerelease: false
+      - name: Bump package version
+        run: |
+          npm version patch --no-git-tag-version ${{ steps.get_package_version.outputs.package_version }}
+          git add --all
+          UPDATED_VERSION=$(node -p "require('./package.json').version")
+          git commit -m "Bump version from ${{ steps.get_package_version.outputs.package_version }} to $UPDATED_VERSION in package.json"
+          git push --set-upstream origin $(git branch --show-current)
+
+      # - name: Create Tag and GitHub Release
+      #   uses: actions/create-release@v1
+      #   env:
+      #     GITHUB_TOKEN: ${{ steps.genberate_github_app_token.outputs.token }}
+      #   with:
+      #     tag_name: ${{ steps.get_package_version.outputs.package_version }}
+      #     release_name: ${{ steps.get_package_version.outputs.package_version }}
+      #     draft: false
+      #     prerelease: false
           

--- a/.github/workflows/bump-tag-release.yml
+++ b/.github/workflows/bump-tag-release.yml
@@ -50,7 +50,7 @@ jobs:
 
       # - name: Create Tag and GitHub Release
       #   uses: actions/create-release@v1
-      #   env: 
+      #   env:
       #     GITHUB_TOKEN: ${{ steps.genberate_github_app_token.outputs.token }}
       #   with:
       #     tag_name: ${{ steps.get_package_version.outputs.package_version }}

--- a/.github/workflows/bump-tag-release.yml
+++ b/.github/workflows/bump-tag-release.yml
@@ -42,7 +42,7 @@ jobs:
 
       - name: Bump package version
         run: |
-          npm version patch --no-git-tag-version ${{ steps.get_package_version.outputs.package_version }}
+          npm version patch --no-git-tag-version
           git add --all
           UPDATED_VERSION=$(node -p "require('./package.json').version")
           git commit -m "Bump version from ${{ steps.get_package_version.outputs.package_version }} to $UPDATED_VERSION in package.json"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,4 @@
-name: Release library by publishing as NPM package to GitHub Packages Registry
+name: Publish as NPM Package to GitHub Packages Registry
 on: 
   release:
     types: [published] # Only when a release is published (not when a draft is created)
@@ -29,7 +29,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 14.x
+          node-version: 16.x
           registry-url: https://npm.pkg.github.com/
           scope: '@remla23-team08'
       

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@remla23-team08/lib",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "A version-aware library that can be asked for its version",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@remla23-team08/lib",
-  "version": "0.0.5",
+  "version": "0.0.1",
   "description": "A version-aware library that can be asked for its version",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@remla23-team08/lib",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "A version-aware library that can be asked for its version",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@remla23-team08/lib",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "A version-aware library that can be asked for its version",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@remla23-team08/lib",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "A version-aware library that can be asked for its version",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@remla23-team08/lib",
-  "version": "0.0.3",
+  "version": "0.0.1",
   "description": "A version-aware library that can be asked for its version",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Adds the functionality to automatically bump the patch version (for now just this) whenever a push to main is done (i.e. a PR is merged to main as the main branch is protected from any pushes from anyone but the GitHub app for our team). This sets off a chain of events that allow the automatic publishing as an npm package.